### PR TITLE
Generate type definitions

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -44,7 +44,8 @@
   },
   "devDependencies": {
     "@types/node": "^18.7.13",
-    "typescript": "^4.8.2"
+    "typescript": "^4.8.2",
+    "vite-plugin-dts": "^1.7.1"
   },
   "repository": {
     "type": "git",

--- a/src/vite.config.ts
+++ b/src/vite.config.ts
@@ -1,10 +1,12 @@
 import { defineConfig } from "vite";
 import path from "path";
+import dts from "vite-plugin-dts";
 
 const name = "astro-sanity";
 
 export default defineConfig(() => {
   return {
+    plugins: [dts()],
     build: {
       lib: {
         entry: path.resolve(__dirname, "index.ts"),


### PR DESCRIPTION
A stab at addressing #13, adds `vite-plugin-dts` to generate type-defs for the biuld. Build output looks like this afterward: 

![image](https://user-images.githubusercontent.com/12721310/214661587-16f6cf66-c518-40fe-9f32-01921727b36b.png)
