### PR TITLE
Fixed sanity deprecation error on astro build

### DIFF
--- a/src/vite-plugin-sanity-init.ts
+++ b/src/vite-plugin-sanity-init.ts
@@ -14,8 +14,8 @@ export function vitePluginSanityInit(config: ClientConfig) {
     async load(id: string) {
       if (id === resolvedVirtualModuleId) {
         return `
-          import client from "@sanity/client";
-          export const sanityClient = client(${JSON.stringify(config)});
+          import {createClient} from "@sanity/client";
+          export const sanityClient = createClient(${JSON.stringify(config)});
         `;
       }
     },


### PR DESCRIPTION
Fixes Issue #24 

This is the only place in the code where the deprecated default export of `@sanity/client` is used, so I replaced it with the proper named export.

**Please verify the change.** I tested it by `npm link`ing the fixed version and it worked fine - no error was printed during build.

